### PR TITLE
add a notebook to demo chatting with the character personality

### DIFF
--- a/notebooks/llm_personality.ipynb
+++ b/notebooks/llm_personality.ipynb
@@ -1,0 +1,292 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": [],
+      "machine_shape": "hm",
+      "gpuType": "A100"
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "accelerator": "GPU"
+  },
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "End1Gt7Js76-"
+      },
+      "outputs": [],
+      "source": [
+        "!pip install transformers accelerate bitsandbytes gradio -U -q"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from transformers import AutoModelForCausalLM, AutoTokenizer\n",
+        "import torch\n",
+        "\n",
+        "model_id = \"HuggingFaceH4/zephyr-7b-beta\"\n",
+        "model = AutoModelForCausalLM.from_pretrained(model_id, torch_dtype=torch.float16, device_map=\"auto\")\n",
+        "tokenizer = AutoTokenizer.from_pretrained(model_id)\n",
+        "tokenizer.use_default_system_prompt = False"
+      ],
+      "metadata": {
+        "id": "e72HaxzatJmz"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "SAMPLE_PERSONALITY = {\n",
+        "    \"characters\": [\n",
+        "        {\n",
+        "            \"name\": \"Alice\",\n",
+        "            \"physicalDescription\": \"Alice is a young woman with long, wavy brown hair and hazel eyes. She is of average height and has a slim build. Her most distinctive feature is her warm, friendly smile.\",\n",
+        "            \"personalityTraits\": [\n",
+        "                \"Alice is a kind, compassionate, and intelligent woman. She is always willing to help others and is a great listener. She is also very creative and has a great sense of humor.\",\n",
+        "            ],\n",
+        "            \"likes\": [\n",
+        "                \"Alice loves spending time with her friends and family.\",\n",
+        "                \"She enjoys reading, writing, and listening to music.\",\n",
+        "                \"She is also a big fan of traveling and exploring new places.\",\n",
+        "            ],\n",
+        "            \"dislikes\": [\n",
+        "                \"Alice dislikes rudeness and cruelty.\",\n",
+        "                \"She also dislikes being lied to or taken advantage of.\",\n",
+        "                \"She is not a fan of heights or roller coasters.\",\n",
+        "            ],\n",
+        "            \"background\": [\n",
+        "                \"Alice grew up in a small town in the Midwest.\",\n",
+        "                \"She was always a good student and excelled in her studies.\",\n",
+        "                \"After graduating from high school, she moved to the city to attend college.\",\n",
+        "                \"She is currently working as a social worker.\",\n",
+        "            ],\n",
+        "            \"goals\": [\n",
+        "                \"Alice wants to make a difference in the world.\",\n",
+        "                \"She hopes to one day open her own counseling practice.\",\n",
+        "                \"She also wants to travel the world and experience different cultures.\",\n",
+        "            ],\n",
+        "            \"relationships\": [\n",
+        "                \"Alice is very close to her family and friends.\",\n",
+        "                \"She is also in a loving relationship with her partner, Ben.\",\n",
+        "                \"She has a good relationship with her colleagues and is well-respected by her clients.\",\n",
+        "            ],\n",
+        "        }\n",
+        "    ]\n",
+        "}"
+      ],
+      "metadata": {
+        "id": "tvhZLGmYt3B0"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "SAMPLE_PERSONALITY[\"characters\"][0].keys()"
+      ],
+      "metadata": {
+        "id": "SyOk6YkHvHlU"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def get_system_prompt(personality_json_dict: dict) -> str:\n",
+        "    \"\"\"Assumes a single character is passed.\"\"\"\n",
+        "    name = personality_json_dict[\"name\"]\n",
+        "    physcial_description = personality_json_dict[\"physicalDescription\"]\n",
+        "    personality_traits = [trait for trait in personality_json_dict[\"personalityTraits\"]]\n",
+        "    likes = [like for like in personality_json_dict[\"likes\"]]\n",
+        "    dislikes = [dislike for dislike in personality_json_dict[\"dislikes\"]]\n",
+        "    background = [info for info in personality_json_dict[\"background\"]]\n",
+        "    goals = [goal for goal in personality_json_dict[\"goals\"]]\n",
+        "    relationships = [relationship for relationship in personality_json_dict[\"relationships\"]]\n",
+        "\n",
+        "    system_prompt = f\"\"\"\n",
+        "You are acting as the character detailed below. The details of the character contain different traits, starting from its inherent personality traits to its background.\n",
+        "\n",
+        "* Name: {name}\n",
+        "* Physical description: {physcial_description}\n",
+        "* Personality traits: {', '.join(personality_traits)}\n",
+        "* Likes: {', '.join(likes)}\n",
+        "* Background: {', '.join(background)}\n",
+        "* Goals: {', '.join(goals)}\n",
+        "* Relationships:  {', '.join(relationships)}\n",
+        "\n",
+        "While generating your responses, you must consider the information above.\n",
+        "\"\"\"\n",
+        "    return system_prompt"
+      ],
+      "metadata": {
+        "id": "Ri_pnhp9thoH"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from pprint import pprint\n",
+        "\n",
+        "pprint(get_system_prompt(SAMPLE_PERSONALITY[\"characters\"][0]))"
+      ],
+      "metadata": {
+        "id": "jIchZaQRwo-V"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import os\n",
+        "\n",
+        "MAX_MAX_NEW_TOKENS = 2048\n",
+        "DEFAULT_MAX_NEW_TOKENS = 1024\n",
+        "MAX_INPUT_TOKEN_LENGTH = int(os.getenv(\"MAX_INPUT_TOKEN_LENGTH\", \"4096\"))"
+      ],
+      "metadata": {
+        "id": "2HUwseXzxN_H"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!wget https://huggingface.co/spaces/huggingface-projects/llama-2-7b-chat/raw/main/style.css --content-disposition"
+      ],
+      "metadata": {
+        "id": "5tbbhUbmx9oV"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import gradio as gr\n",
+        "from threading import Thread\n",
+        "from transformers import TextIteratorStreamer\n",
+        "\n",
+        "def generate(\n",
+        "    message: str,\n",
+        "    chat_history: list[tuple[str, str]],\n",
+        "    max_new_tokens: int = 1024,\n",
+        "    temperature: float = 0.6,\n",
+        "    top_p: float = 0.9,\n",
+        "    top_k: int = 50,\n",
+        "    repetition_penalty: float = 1.2,\n",
+        "):\n",
+        "    conversation = []\n",
+        "    system_prompt = get_system_prompt(SAMPLE_PERSONALITY[\"characters\"][0])\n",
+        "    conversation.append({\"role\": \"system\", \"content\": system_prompt})\n",
+        "    for user, assistant in chat_history:\n",
+        "        conversation.extend([{\"role\": \"user\", \"content\": user}, {\"role\": \"assistant\", \"content\": assistant}])\n",
+        "    conversation.append({\"role\": \"user\", \"content\": message})\n",
+        "\n",
+        "    input_ids = tokenizer.apply_chat_template(conversation, return_tensors=\"pt\")\n",
+        "    if input_ids.shape[1] > MAX_INPUT_TOKEN_LENGTH:\n",
+        "        input_ids = input_ids[:, -MAX_INPUT_TOKEN_LENGTH:]\n",
+        "        gr.Warning(f\"Trimmed input from conversation as it was longer than {MAX_INPUT_TOKEN_LENGTH} tokens.\")\n",
+        "    input_ids = input_ids.to(model.device)\n",
+        "\n",
+        "    streamer = TextIteratorStreamer(tokenizer, timeout=10.0, skip_prompt=True, skip_special_tokens=True)\n",
+        "    generate_kwargs = dict(\n",
+        "        {\"input_ids\": input_ids},\n",
+        "        streamer=streamer,\n",
+        "        max_new_tokens=max_new_tokens,\n",
+        "        do_sample=True,\n",
+        "        top_p=top_p,\n",
+        "        top_k=top_k,\n",
+        "        temperature=temperature,\n",
+        "        num_beams=1,\n",
+        "        repetition_penalty=repetition_penalty,\n",
+        "    )\n",
+        "    t = Thread(target=model.generate, kwargs=generate_kwargs)\n",
+        "    t.start()\n",
+        "\n",
+        "    outputs = []\n",
+        "    for text in streamer:\n",
+        "        outputs.append(text.replace(\"<|assistant|>\", \"\"))\n",
+        "        yield \"\".join(outputs)\n",
+        "\n",
+        "\n",
+        "chat_interface = gr.ChatInterface(\n",
+        "    fn=generate,\n",
+        "    additional_inputs=[\n",
+        "        gr.Slider(\n",
+        "            label=\"Max new tokens\",\n",
+        "            minimum=1,\n",
+        "            maximum=MAX_MAX_NEW_TOKENS,\n",
+        "            step=1,\n",
+        "            value=DEFAULT_MAX_NEW_TOKENS,\n",
+        "        ),\n",
+        "        gr.Slider(\n",
+        "            label=\"Temperature\",\n",
+        "            minimum=0.1,\n",
+        "            maximum=4.0,\n",
+        "            step=0.1,\n",
+        "            value=0.6,\n",
+        "        ),\n",
+        "        gr.Slider(\n",
+        "            label=\"Top-p (nucleus sampling)\",\n",
+        "            minimum=0.05,\n",
+        "            maximum=1.0,\n",
+        "            step=0.05,\n",
+        "            value=0.9,\n",
+        "        ),\n",
+        "        gr.Slider(\n",
+        "            label=\"Top-k\",\n",
+        "            minimum=1,\n",
+        "            maximum=1000,\n",
+        "            step=1,\n",
+        "            value=50,\n",
+        "        ),\n",
+        "        gr.Slider(\n",
+        "            label=\"Repetition penalty\",\n",
+        "            minimum=1.0,\n",
+        "            maximum=2.0,\n",
+        "            step=0.05,\n",
+        "            value=1.2,\n",
+        "        ),\n",
+        "    ],\n",
+        "    stop_btn=None,\n",
+        "    examples=[\n",
+        "        [\"Hello there! How are you doing?\"],\n",
+        "        [\"Recite me a short poem.\"],\n",
+        "        [\"Explain the plot of Cinderella in a sentence.\"],\n",
+        "        [\"Write a 100-word article on 'Benefits of Open-Source in AI research'\"],\n",
+        "    ],\n",
+        ")\n",
+        "\n",
+        "with gr.Blocks(css=\"style.css\") as demo:\n",
+        "    gr.Markdown(\"## Demo of Vid2Persona chat component\")\n",
+        "    gr.DuplicateButton(value=\"Duplicate Space for private use\", elem_id=\"duplicate-button\")\n",
+        "    chat_interface.render()\n",
+        "\n",
+        "demo.launch()"
+      ],
+      "metadata": {
+        "id": "Cvot5sxWw5sB"
+      },
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}


### PR DESCRIPTION
Adds a notebook to show how to implement a simple chat interface with `"HuggingFaceH4/zephyr-7b-beta"` for a given character. Shows utilities to:

* create a system prompt a single character and its traits as predicted by the upstream VLM.
* streamer for chat
* `gradio` app